### PR TITLE
:rotating_light: #19 Set linkXRef property to false inside PMD configuration to avoid warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
                     <!-- this is actually true by default, but can be disabled -->
                     <failOnViolation>true</failOnViolation>
                     <printFailingErrors>true</printFailingErrors>
+                    <linkXRef>false</linkXRef>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This PR removes the warning reported on #19 

Closes #19 