### PR TITLE
:chart_with_upwards_trend: #28 Add JaCoCo plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <maven-failsafe-plugin.version>2.21.0</maven-failsafe-plugin.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
         <plugin.prettier.goal>write</plugin.prettier.goal>
+        <plugin.jacoco.version>0.8.8</plugin.jacoco.version>
     </properties>
     <name>task-timer</name>
     <url>http://maven.apache.org</url>
@@ -225,6 +226,25 @@
                         <phase>validate</phase>
                         <goals>
                             <goal>${plugin.prettier.goal}</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${plugin.jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR adds the basic configuration to collect the Code coverage using the JaCoCo plugin.

<img width="1433" alt="Captura de Pantalla 2023-09-27 a la(s) 20 28 12" src="https://github.com/DevelopersDelicias/task-timer/assets/6618534/f11842fa-8c70-44cf-bdd8-a1eaea73157e">

Closes #28
